### PR TITLE
кузина варвара мо 231

### DIFF
--- a/SpaceBattle.Lib/Rotation/Angle.cs
+++ b/SpaceBattle.Lib/Rotation/Angle.cs
@@ -1,0 +1,43 @@
+﻿namespace SpaceBattle.Lib;
+
+public class Angle
+{
+    private int Numerator { get; set; }
+    private int DNumerator { get; }
+
+    public Angle(int Numerator, int DNumerator)
+    {
+        this.Numerator = ((Numerator % DNumerator) + DNumerator) % DNumerator;
+        this.DNumerator = DNumerator;
+    }
+
+    public static Angle operator +(Angle angle_1, Angle angle_2)
+    {
+        return new Angle(angle_1.Numerator + angle_2.Numerator, angle_1.DNumerator);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj != null && obj is Angle angle && angle.Numerator == Numerator && angle.DNumerator == DNumerator;
+    }
+
+    public static bool operator ==(Angle angle_1, Angle angle_2)
+    {
+        return angle_1.Equals(angle_2);
+    }
+
+    public static bool operator !=(Angle angle_1, Angle angle_2)
+    {
+        return !(angle_1.Equals(angle_2));
+    }
+
+    public override int GetHashCode()
+    {
+        return Numerator.GetHashCode();
+    }
+
+    public static implicit operator double(Angle angle)
+    {
+        return 2 * Math.PI * angle.Numerator / angle.DNumerator;
+    }
+}

--- a/SpaceBattle.Lib/Rotation/IRotating.cs
+++ b/SpaceBattle.Lib/Rotation/IRotating.cs
@@ -1,0 +1,7 @@
+﻿namespace SpaceBattle.Lib;
+
+public interface IRotating
+{
+    Angle AnglePosition { get; set; }
+    Angle RotateVelocity { get; }
+}

--- a/SpaceBattle.Lib/Rotation/RegisterIoCDependencyRotateCommand.cs
+++ b/SpaceBattle.Lib/Rotation/RegisterIoCDependencyRotateCommand.cs
@@ -1,0 +1,13 @@
+﻿namespace SpaceBattle.Lib;
+
+public class RegisterIoCDependencyRotateCommand : ICommand
+{
+    public void Execute()
+    {
+        IoC.Resolve<ICommand>(
+            "IoC.Register",
+            "Commands.Rotate",
+            (object[] args) => new RotateCommand(IoC.Resolve<IRotating>("Adapters.IRotatingObject", args[0]))
+        ).Execute();
+    }
+}

--- a/SpaceBattle.Lib/Rotation/RotateCommand.cs
+++ b/SpaceBattle.Lib/Rotation/RotateCommand.cs
@@ -1,0 +1,15 @@
+﻿namespace SpaceBattle.Lib;
+
+public class RotateCommand : ICommand
+{
+    private readonly IRotating obj;
+
+    public RotateCommand(IRotating obj)
+    {
+        this.obj = obj;
+    }
+    public void Execute()
+    {
+        obj.AnglePosition = obj.AnglePosition + obj.RotateVelocity;
+    }
+}

--- a/SpaceBattle.Tests/RotationTests/AngleTest.cs
+++ b/SpaceBattle.Tests/RotationTests/AngleTest.cs
@@ -1,0 +1,68 @@
+﻿namespace SpaceBattle.Tests;
+using SpaceBattle.Lib;
+
+public class AngleTest
+{
+    [Fact]
+    public void AngleSum()
+    {
+        var angle_1 = new Angle(5, 8);
+        var angle_2 = new Angle(7, 8);
+        Assert.Equal(new Angle(4, 8), angle_1 + angle_2);
+    }
+
+    [Fact]
+    public void EqualsTest_True()
+    {
+        var angle_1 = new Angle(15, 8);
+        var angle_2 = new Angle(23, 8);
+        Assert.True(angle_1.Equals(angle_2));
+    }
+
+    [Fact]
+    public void OperatorEqualsTest_True()
+    {
+        var angle_1 = new Angle(15, 8);
+        var angle_2 = new Angle(23, 8);
+        Assert.True(angle_1 == angle_2);
+    }
+
+    [Fact]
+    public void EqualsTest_False()
+    {
+        var angle_1 = new Angle(1, 8);
+        var angle_2 = new Angle(2, 8);
+        Assert.False(angle_1.Equals(angle_2));
+    }
+
+    [Fact]
+    public void OperatorNotEqualsTest_True()
+    {
+        var angle_1 = new Angle(1, 8);
+        var angle_2 = new Angle(2, 8);
+        Assert.True(angle_1 != angle_2);
+    }
+
+    [Fact]
+    public void GetHashCodeTest()
+    {
+        var angle_1 = new Angle(6, 8);
+        var angle_2 = new Angle(6, 8);
+        var hashcode = angle_1.GetHashCode();
+        Assert.Equal(hashcode, angle_2.GetHashCode());
+    }
+
+    [Fact]
+    public void SinTest()
+    {
+        var angle = new Angle(2, 8);
+        Assert.Equal(1.0, Math.Round(Math.Sin(angle), 3));
+    }
+
+    [Fact]
+    public void CosTest()
+    {
+        var angle = new Angle(0, 8);
+        Assert.Equal(1.0, Math.Round(Math.Cos(angle), 3));
+    }
+}

--- a/SpaceBattle.Tests/RotationTests/RegisterIoCDependencyRotateCommandTest.cs
+++ b/SpaceBattle.Tests/RotationTests/RegisterIoCDependencyRotateCommandTest.cs
@@ -1,0 +1,38 @@
+﻿
+using Hwdtech.Ioc;
+using SpaceBattle.Lib;
+
+namespace SpaceBattle.Tests
+{
+    public class RegisterIoCDependencyRotateCommandTests
+    {
+        public RegisterIoCDependencyRotateCommandTests()
+        {
+            new InitScopeBasedIoCImplementationCommand().Execute();
+            IoC.Resolve<ICommand>("Scopes.Current.Set",
+            IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
+        }
+
+        [Fact]
+        public void Execute_Should_Register_Rotate_Command_Dependency()
+        {
+            var gameObject = new Dictionary<string, object>();
+
+            var rotating = new Mock<IRotating>();
+
+            rotating.SetupGet(x => x.AnglePosition).Returns(new Angle(45, 8));
+            rotating.SetupGet(x => x.RotateVelocity).Returns(new Angle(90, 8));
+
+            var cmd = new RegisterIoCDependencyRotateCommand();
+
+            IoC.Resolve<ICommand>("IoC.Register", "Adapters.IRotatingObject", (object[] args) => rotating.Object).Execute();
+
+            cmd.Execute();
+
+            var rotateCommand = IoC.Resolve<ICommand>("Commands.Rotate", gameObject);
+            rotateCommand.Execute();
+
+            Assert.IsType<RotateCommand>(rotateCommand);
+        }
+    }
+}

--- a/SpaceBattle.Tests/RotationTests/RotateCommandTest.cs
+++ b/SpaceBattle.Tests/RotationTests/RotateCommandTest.cs
@@ -1,0 +1,47 @@
+﻿using SpaceBattle.Lib;
+namespace SpaceBattle.Tests;
+
+public class RotateCommandTest
+{
+    [Fact]
+    public void Rotating45_Velocity90Test()
+    {
+        var rotatingObj = new Mock<IRotating>();
+        rotatingObj.SetupGet(x => x.AnglePosition).Returns(new Angle(45, 8));
+        rotatingObj.SetupGet(x => x.RotateVelocity).Returns(new Angle(45, 8));
+        var rotateCommand = new RotateCommand(rotatingObj.Object);
+        rotateCommand.Execute();
+        rotatingObj.VerifySet(x => x.AnglePosition = new Angle(90, 8));
+    }
+
+    [Fact]
+    public void NoAnglePositionTest()
+    {
+        var rotatingObj = new Mock<IRotating>();
+        rotatingObj.SetupGet(x => x.AnglePosition).Throws<Exception>();
+        rotatingObj.SetupGet(x => x.RotateVelocity).Returns(new Angle(90, 8));
+        var rotateCommand = new RotateCommand(rotatingObj.Object);
+        Assert.Throws<Exception>(() => rotateCommand.Execute());
+    }
+
+    [Fact]
+    public void NoRotateVelocityTest()
+    {
+        var rotatingObj = new Mock<IRotating>();
+        rotatingObj.SetupGet(x => x.AnglePosition).Returns(new Angle(45, 8));
+        rotatingObj.SetupGet(x => x.RotateVelocity).Throws<Exception>();
+        var rotateCommand = new RotateCommand(rotatingObj.Object);
+        Assert.Throws<Exception>(() => rotateCommand.Execute());
+    }
+
+    [Fact]
+    public void CantChangeAnglePosTest()
+    {
+        var rotatingObj = new Mock<IRotating>();
+        rotatingObj.SetupGet(x => x.AnglePosition).Returns(new Angle(0, 8));
+        rotatingObj.SetupSet(x => x.AnglePosition = It.IsAny<Angle>()).Throws<Exception>();
+        rotatingObj.SetupGet(x => x.RotateVelocity).Returns(new Angle(657, 8));
+        var rotateCommand = new RotateCommand(rotatingObj.Object);
+        Assert.Throws<Exception>(() => rotateCommand.Execute());
+    }
+}


### PR DESCRIPTION
7. Угол на плоскости.
Для представления угла наклона к оси OX игрового объекта реализовать класс Angle. Внутри Angle представлен как рациональное число, причем знаменатель у всех углов будет одинаковый (его можно сделать статическим полем). Для угла должна быть реализована операция сложения и должна быть возможность вычисления синуса и косинуса от Angle без предварительного явного приведения к типу Double: Math.Cos(angle).

Критерии приемки:

Реализован тест, который проверяет, что при сложении углов (5, 8) и (7, 8) получается вектор (4,8).
Реализован тест, который проверят, что два угла (15, 8) и (23, 8), равны между собой при сравнении через метод Equals.
Реализован тест, который проверят, что два угла (15, 8) и (23, 8), равны между собой при сравнении через метод ==.
Реализован тест, который проверят, что углы (1,8) и (2, 8) неравны между собой при сравнении через метод Equals.
Реализован тест, который проверят, что углы (1,8) и (2, 8) неравны между собой при сравнении через метод !=.
Реализован тест, который проверяет наличие хэш-кода у угла.
8. Определить команду Rotate для равномерного вращения вокруг собственной оси.
Команда выполняет равномерное поступальное движение объекта без деформации за один дискретный момент времени.

Критерии приемки:

Реализован тест, который проверяет, что если вращающийся объект имеет угол наклона 45 градусов к оси OX и имеет мгновенную угловую скорость скорость 45 градусов, то в следующий дискретный момент времени угол наклона к оси OX будет 90 градусов.
Реализован тест, который проверяет, что если невозможно определить угол наклона объекта к оси OX, то команда Rotate выбрасывает исключение.
Реализован тест, который проверяет, что если у вращающегося объекта невозможно определить мгновенную угловую скорость, то команда Rotate выбрасывает исключение.
Реализован тест, который проверяет, что еcли у движущегося объекта невозможно изменить угол наклона к оси OX, то команда Rotate выбрасывает исключение.
9. Регистрация зависимости Commands.Rotate в IoC.
Зарегистрировать зависимость "Commands.Rotate" в IoC, с помощью которой можно разрешить команду MoveCommand по игровому объекту. Для регистрации зависимости определить отдельную команду с префиксом RegisterIoCDependency:

public class RegisterIoCDependencyRotateCommand : ICommand
{
    public void Execute()
  {
      // код, регистрирующий зависимость
    }
}
Примечание: Для того, чтобы создать RotateCommand, необходимо создать адаптер IDictionary<string, object> для интерфейса IRotatingObject. Задача конструирования Адаптеров по интерфейсу будет рассмотрена в другой лабораторной работе, поэтому в данной задаче используйте разрешение зависимости Ioc.Resolve("Adapters.IRotatingObject", obj), где obj - игровой объект. В тестах используйте Mock-объекты, для разрешения этой зависимости.

Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterIoCDependencyRotateCommand зависимость разрешается.