### PR TITLE
Ivanov denis

### DIFF
--- a/SpaceBattle.Lib/Commands/EmptyCommand.cs
+++ b/SpaceBattle.Lib/Commands/EmptyCommand.cs
@@ -1,0 +1,8 @@
+﻿namespace SpaceBattle.Lib;
+public class EmptyCommand : ICommand
+{
+    public void Execute()
+    {
+
+    }
+}

--- a/SpaceBattle.Lib/Commands/SendCommand.cs
+++ b/SpaceBattle.Lib/Commands/SendCommand.cs
@@ -1,6 +1,4 @@
-using SpaceBattle.Lib;
-
-namespace SpaceBattle.Lib
+﻿namespace SpaceBattle.Lib
 {
     public class SendCommand : ICommand
     {

--- a/SpaceBattle.Lib/Commands/SendCommand.cs
+++ b/SpaceBattle.Lib/Commands/SendCommand.cs
@@ -1,19 +1,18 @@
-﻿namespace SpaceBattle.Lib
+﻿namespace SpaceBattle.Lib;
+
+public class SendCommand : ICommand
 {
-    public class SendCommand : ICommand
+    private readonly ICommand _command;
+    private readonly ICommandReceiver _receiver;
+
+    public SendCommand(ICommand command, ICommandReceiver receiver)
     {
-        private readonly ICommand _command;
-        private readonly ICommandReceiver _receiver;
+        _command = command;
+        _receiver = receiver;
+    }
 
-        public SendCommand(ICommand command, ICommandReceiver receiver)
-        {
-            _command = command;
-            _receiver = receiver;
-        }
-
-        public void Execute()
-        {
-            _receiver.Receive(_command);
-        }
+    public void Execute()
+    {
+        _receiver.Receive(_command);
     }
 }

--- a/SpaceBattle.Lib/Commands/SendCommand.cs
+++ b/SpaceBattle.Lib/Commands/SendCommand.cs
@@ -1,0 +1,21 @@
+using SpaceBattle.Lib;
+
+namespace SpaceBattle.Lib
+{
+    public class SendCommand : ICommand
+    {
+        private readonly ICommand _command;
+        private readonly ICommandReceiver _receiver;
+
+        public SendCommand(ICommand command, ICommandReceiver receiver)
+        {
+            _command = command;
+            _receiver = receiver;
+        }
+
+        public void Execute()
+        {
+            _receiver.Receive(_command);
+        }
+    }
+}

--- a/SpaceBattle.Lib/Commands/StartCommand.cs
+++ b/SpaceBattle.Lib/Commands/StartCommand.cs
@@ -1,0 +1,17 @@
+﻿namespace SpaceBattle.Lib;
+
+public class StartCommand(IDictionary<string, object> gameObject, string action) : ICommand
+{
+    public void Execute()
+    {
+        var command = IoC.Resolve<ICommand>($"Commands.{action}", gameObject);
+        var injectable = (ICommand)IoC.Resolve<ICommandInjectable>("Commands.CommandInjectable");
+        var commandReceiver = IoC.Resolve<ICommandReceiver>("Game.CommandsReceiver");
+        var sendCommand = new SendCommand(injectable, commandReceiver);
+        var result = IoC.Resolve<ICommand>($"Macro.{action}", command, sendCommand);
+        ((ICommandInjectable)injectable).Inject(result);
+        gameObject[$"repeatable{action}"] = injectable;
+        var finalCommand = new SendCommand(result, commandReceiver);
+        finalCommand.Execute();
+    }
+}

--- a/SpaceBattle.Lib/Commands/StartCommand.cs
+++ b/SpaceBattle.Lib/Commands/StartCommand.cs
@@ -7,11 +7,11 @@ public class StartCommand(IDictionary<string, object> gameObject, string action)
         var command = IoC.Resolve<ICommand>($"Commands.{action}", gameObject);
         var injectable = (ICommand)IoC.Resolve<ICommandInjectable>("Commands.CommandInjectable");
         var commandReceiver = IoC.Resolve<ICommandReceiver>("Game.CommandsReceiver");
-        var sendCommand = new SendCommand(injectable, commandReceiver);
+        var sendCommand = IoC.Resolve<ICommand>("Commands.Send", injectable, commandReceiver);
         var result = IoC.Resolve<ICommand>($"Macro.{action}", command, sendCommand);
         ((ICommandInjectable)injectable).Inject(result);
         gameObject[$"repeatable{action}"] = injectable;
-        var finalCommand = new SendCommand(result, commandReceiver);
+        var finalCommand = IoC.Resolve<ICommand>("Commands.Send", result, commandReceiver);
         finalCommand.Execute();
     }
 }

--- a/SpaceBattle.Lib/Commands/StopCommand.cs
+++ b/SpaceBattle.Lib/Commands/StopCommand.cs
@@ -1,0 +1,18 @@
+﻿namespace SpaceBattle.Lib;
+
+public class StopCommand(IDictionary<string, object> gameObject, string action) : ICommand
+{
+    public void Execute()
+    {
+        var objInjectable = $"Long.{action}";
+
+        if (!gameObject.ContainsKey(objInjectable))
+        {
+            throw new InvalidOperationException($"{action} не начат, остановка {action} невозможна");
+        }
+
+        var injectable = (ICommandInjectable)gameObject[objInjectable];
+        injectable.Inject(new EmptyCommand());
+        gameObject.Remove(objInjectable);
+    }
+}

--- a/SpaceBattle.Lib/IoC/RegisterIoCDependencyActionsStart.cs
+++ b/SpaceBattle.Lib/IoC/RegisterIoCDependencyActionsStart.cs
@@ -1,0 +1,12 @@
+﻿namespace SpaceBattle.Lib;
+
+public class RegisterIoCDependencyActionsStart : ICommand
+{
+    public void Execute()
+    {
+        IoC.Resolve<ICommand>(
+            "IoC.Register",
+            "Actions.Start",
+            (object[] args) => { return new StartCommand((IDictionary<string, object>)args[0], (string)args[1]); }).Execute();
+    }
+}

--- a/SpaceBattle.Lib/IoC/RegisterIoCDependencyActionsStop.cs
+++ b/SpaceBattle.Lib/IoC/RegisterIoCDependencyActionsStop.cs
@@ -1,0 +1,12 @@
+﻿namespace SpaceBattle.Lib;
+
+public class RegisterIoCDependencyActionsStop : ICommand
+{
+    public void Execute()
+    {
+        IoC.Resolve<ICommand>(
+            "IoC.Register",
+            "Actions.Stop",
+            (object[] args) => { return new StopCommand((IDictionary<string, object>)args[0], (string)args[1]); }).Execute();
+    }
+}

--- a/SpaceBattle.Lib/IoC/RegisterIoCDependencySendCommand.cs
+++ b/SpaceBattle.Lib/IoC/RegisterIoCDependencySendCommand.cs
@@ -1,13 +1,10 @@
-using Hwdtech.Ioc;
-using SpaceBattle.Lib;
-
-namespace SpaceBattle.Lib
+﻿namespace SpaceBattle.Lib
 {
     public class RegisterIoCDependencySendCommand : ICommand
     {
         public void Execute()
         {
-            IoC.Resolve<ICommand>("IoC.Register", "Commands.Send", 
+            IoC.Resolve<ICommand>("IoC.Register", "Commands.Send",
                 (object[] args) => new SendCommand((ICommand)args[0], (ICommandReceiver)args[1])
             ).Execute();
         }

--- a/SpaceBattle.Lib/IoC/RegisterIoCDependencySendCommand.cs
+++ b/SpaceBattle.Lib/IoC/RegisterIoCDependencySendCommand.cs
@@ -1,0 +1,15 @@
+using Hwdtech.Ioc;
+using SpaceBattle.Lib;
+
+namespace SpaceBattle.Lib
+{
+    public class RegisterIoCDependencySendCommand : ICommand
+    {
+        public void Execute()
+        {
+            IoC.Resolve<ICommand>("IoC.Register", "Commands.Send", 
+                (object[] args) => new SendCommand((ICommand)args[0], (ICommandReceiver)args[1])
+            ).Execute();
+        }
+    }
+}

--- a/SpaceBattle.Lib/interfaces/ICommandReceiver.cs
+++ b/SpaceBattle.Lib/interfaces/ICommandReceiver.cs
@@ -1,4 +1,4 @@
-namespace SpaceBattle.Lib
+﻿namespace SpaceBattle.Lib
 {
     public interface ICommandReceiver
     {

--- a/SpaceBattle.Lib/interfaces/ICommandReceiver.cs
+++ b/SpaceBattle.Lib/interfaces/ICommandReceiver.cs
@@ -1,0 +1,7 @@
+namespace SpaceBattle.Lib
+{
+    public interface ICommandReceiver
+    {
+        void Receive(ICommand command);
+    }
+}

--- a/SpaceBattle.Lib/interfaces/Injectable.cs
+++ b/SpaceBattle.Lib/interfaces/Injectable.cs
@@ -1,4 +1,4 @@
-namespace SpaceBattle.Lib;
+﻿namespace SpaceBattle.Lib;
 
 public interface ICommandInjectable
 

--- a/SpaceBattle.Lib/interfaces/Injectable.cs
+++ b/SpaceBattle.Lib/interfaces/Injectable.cs
@@ -1,7 +1,0 @@
-namespace SpaceBattle.Lib;
-
-public interface ICommandInjectable
-
-{
-    void Inject(ICommand command);
-}

--- a/SpaceBattle.Lib/interfaces/Injectable.cs
+++ b/SpaceBattle.Lib/interfaces/Injectable.cs
@@ -1,0 +1,7 @@
+namespace SpaceBattle.Lib;
+
+public interface ICommandInjectable
+
+{
+    void Inject(ICommand command);
+}

--- a/SpaceBattle.Tests/CommandTest/EmptyCommandTest.cs
+++ b/SpaceBattle.Tests/CommandTest/EmptyCommandTest.cs
@@ -1,0 +1,13 @@
+﻿using SpaceBattle.Lib;
+
+namespace SpaceBattle.Tests;
+
+public class EmptyCommandTest
+{
+    [Fact]
+    public void EmptyCommand_ExecuteDoesNotThrow()
+    {
+        var command = new EmptyCommand();
+        Assert.Null(Record.Exception(() => command.Execute()));
+    }
+}

--- a/SpaceBattle.Tests/CommandTest/SendCommandTests.cs
+++ b/SpaceBattle.Tests/CommandTest/SendCommandTests.cs
@@ -20,19 +20,17 @@ namespace SpaceBattle.Tests
         {
             _messageHandler.Setup(x => x.Receive(_longRunningTask.Object));
             _sendCommand.Execute();
-            _messageHandler.Verify(handler => handler.Receive(_longRunningTask.Object), Times.Once);
+            _messageHandler.Verify(handler => handler.Receive(_longRunningTask.Object), Times.Once());
         }
 
         [Fact]
         public void SendCommand_Propagates_Handler_Exception()
         {
-            var expectedError = new Exception("Handler failure");
             _messageHandler
-                .Setup(handler => handler.Receive(It.IsAny<ICommand>()))
-                .Throws(expectedError);
+                .Setup(handler => handler.Receive(_longRunningTask.Object))
+                .Throws<Exception>();
 
-            var actualError = Assert.Throws<Exception>(() => _sendCommand.Execute());
-            Assert.Same(expectedError, actualError);
+            Assert.Throws<Exception>(() => _sendCommand.Execute());
         }
     }
 }

--- a/SpaceBattle.Tests/CommandTest/StartCommandTests.cs
+++ b/SpaceBattle.Tests/CommandTest/StartCommandTests.cs
@@ -1,0 +1,66 @@
+﻿namespace SpaceBattle.Tests;
+
+using Hwdtech;
+using Hwdtech.Ioc;
+using Moq;
+using SpaceBattle.Lib;
+
+public class StartCommandTests
+{
+    private readonly Mock<ICommand> _moveCommand;
+    private readonly Mock<ICommandInjectable> _injectableCommand;
+    private readonly Mock<ICommandReceiver> _commandReceiver;
+    private readonly Dictionary<string, object> _obj;
+
+    public StartCommandTests()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        IoC.Resolve<ICommand>("Scopes.Current.Set",
+            IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))
+        ).Execute();
+
+        _moveCommand = new Mock<ICommand>();
+        _injectableCommand = new Mock<ICommand>().As<ICommandInjectable>();
+        _commandReceiver = new Mock<ICommandReceiver>();
+        _obj = new Dictionary<string, object>();
+
+        RegisterDependencies();
+    }
+
+    private void RegisterDependencies()
+    {
+        IoC.Resolve<ICommand>("IoC.Register", "Commands.Move",
+            (object[] args) => _moveCommand.Object).Execute();
+
+        IoC.Resolve<ICommand>("IoC.Register", "Commands.CommandInjectable",
+            (object[] args) => _injectableCommand.Object).Execute();
+
+        IoC.Resolve<ICommand>("IoC.Register", "Macro.Move",
+            (object[] args) => _moveCommand.Object).Execute();
+
+        IoC.Resolve<ICommand>("IoC.Register", "Game.CommandsReceiver",
+            (object[] args) => _commandReceiver.Object).Execute();
+
+        new RegisterIoCDependencySendCommand().Execute();
+    }
+
+    [Fact]
+    public void Execute_CreatesAndRegistersCommand()
+    {
+        var startCommand = new StartCommand(_obj, "Move");
+
+        startCommand.Execute();
+
+        Assert.True(_obj.ContainsKey("repeatableMove"));
+    }
+
+    [Fact]
+    public void Execute_SendsCommandToReceiver()
+    {
+        var startCommand = new StartCommand(_obj, "Move");
+
+        startCommand.Execute();
+
+        _commandReceiver.Verify(r => r.Receive(It.IsAny<ICommand>()), Times.Once());
+    }
+}

--- a/SpaceBattle.Tests/CommandTest/StopCommandTests.cs
+++ b/SpaceBattle.Tests/CommandTest/StopCommandTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace SpaceBattle.Tests;
 
-using System.Diagnostics;
 using Hwdtech;
 using Hwdtech.Ioc;
 using SpaceBattle.Lib;

--- a/SpaceBattle.Tests/CommandTest/StopCommandTests.cs
+++ b/SpaceBattle.Tests/CommandTest/StopCommandTests.cs
@@ -50,18 +50,6 @@ public class StopCommandTests
     }
 
     [Fact]
-    public void Execute_CompletesQuickly()
-    {
-        var stopCommand = new StopCommand(_obj, CommandType);
-        var timer = Stopwatch.StartNew();
-
-        stopCommand.Execute();
-
-        timer.Stop();
-        Assert.True(timer.ElapsedMilliseconds < 50);
-    }
-
-    [Fact]
     public void Execute_ThrowsWhenNoCommandFound()
     {
         var emptyObj = new Dictionary<string, object>();

--- a/SpaceBattle.Tests/CommandTest/StopCommandTests.cs
+++ b/SpaceBattle.Tests/CommandTest/StopCommandTests.cs
@@ -1,0 +1,73 @@
+﻿namespace SpaceBattle.Tests;
+
+using System.Diagnostics;
+using Hwdtech;
+using Hwdtech.Ioc;
+using SpaceBattle.Lib;
+
+public class StopCommandTests
+{
+    private readonly Mock<ICommandInjectable> _injectableCommand;
+    private readonly Dictionary<string, object> _obj;
+    private const string CommandType = "Move";
+    private const string CommandKey = "Long";
+
+    public StopCommandTests()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        IoC.Resolve<ICommand>("Scopes.Current.Set",
+            IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))
+        ).Execute();
+
+        _injectableCommand = new Mock<ICommandInjectable>();
+        _obj = new Dictionary<string, object>();
+        InitializeGameObject();
+    }
+
+    private void InitializeGameObject()
+    {
+        _obj[$"{CommandKey}.{CommandType}"] = _injectableCommand.Object;
+    }
+
+    [Fact]
+    public void Execute_InjectsEmptyCommand()
+    {
+        var stopCommand = new StopCommand(_obj, CommandType);
+
+        stopCommand.Execute();
+
+        _injectableCommand.Verify(c => c.Inject(It.IsAny<EmptyCommand>()));
+    }
+
+    [Fact]
+    public void Execute_RemovesCommandFromDictionary()
+    {
+        var stopCommand = new StopCommand(_obj, CommandType);
+
+        stopCommand.Execute();
+
+        Assert.False(_obj.ContainsKey($"{CommandKey}.{CommandType}"));
+    }
+
+    [Fact]
+    public void Execute_CompletesQuickly()
+    {
+        var stopCommand = new StopCommand(_obj, CommandType);
+        var timer = Stopwatch.StartNew();
+
+        stopCommand.Execute();
+
+        timer.Stop();
+        Assert.True(timer.ElapsedMilliseconds < 50);
+    }
+
+    [Fact]
+    public void Execute_ThrowsWhenNoCommandFound()
+    {
+        var emptyObj = new Dictionary<string, object>();
+        var stopCommand = new StopCommand(emptyObj, CommandType);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => stopCommand.Execute());
+        Assert.Contains("не начат, остановка", exception.Message.ToLower());
+    }
+}

--- a/SpaceBattle.Tests/IoC/RegisterDependencySendCommandTests.cs
+++ b/SpaceBattle.Tests/IoC/RegisterDependencySendCommandTests.cs
@@ -1,0 +1,32 @@
+using Hwdtech.Ioc;
+using Moq;
+using SpaceBattle.Lib;
+
+namespace SpaceBattle.Tests
+{
+    public class RegisterDependencySendCommandTests
+    {
+        public RegisterDependencySendCommandTests()
+        {
+            new InitScopeBasedIoCImplementationCommand().Execute();
+            IoC.Resolve<ICommand>("Scopes.Current.Set",
+                IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
+        }
+
+        [Fact]
+        public void Execute_RegistersDependency()
+        {
+            // Arrange
+            var command = new Mock<ICommand>();
+            var receiver = new Mock<ICommandReceiver>();
+
+            // Act
+            new RegisterIoCDependencySendCommand().Execute();
+
+            // Assert
+            var resolvedCommand = IoC.Resolve<ICommand>("Commands.Send", command.Object, receiver.Object);
+            Assert.NotNull(resolvedCommand);
+            Assert.IsType<SendCommand>(resolvedCommand);
+        }
+    }
+}

--- a/SpaceBattle.Tests/IoC/RegisterDependencySendCommandTests.cs
+++ b/SpaceBattle.Tests/IoC/RegisterDependencySendCommandTests.cs
@@ -1,5 +1,4 @@
-using Hwdtech.Ioc;
-using Moq;
+﻿using Hwdtech.Ioc;
 using SpaceBattle.Lib;
 
 namespace SpaceBattle.Tests

--- a/SpaceBattle.Tests/IoC/RegisterDependencySendCommandTests.cs
+++ b/SpaceBattle.Tests/IoC/RegisterDependencySendCommandTests.cs
@@ -33,11 +33,6 @@ namespace SpaceBattle.Tests
         {
             new RegisterIoCDependencySendCommand().Execute();
             var command = IoC.Resolve<ICommand>(SendCommandDependency, _command.Object, _receiver.Object);
-            ValidateCommand(command);
-        }
-
-        private void ValidateCommand(ICommand command)
-        {
             Assert.NotNull(command);
             Assert.IsType<SendCommand>(command);
         }

--- a/SpaceBattle.Tests/IoC/RegisterIoCDependencyActionsStartTests.cs
+++ b/SpaceBattle.Tests/IoC/RegisterIoCDependencyActionsStartTests.cs
@@ -1,0 +1,44 @@
+﻿namespace SpaceBattle.Tests;
+
+using Hwdtech;
+using Hwdtech.Ioc;
+using SpaceBattle.Lib;
+
+public class RegisterIoCDependencyActionsStartTests
+{
+    private readonly Dictionary<string, object> _testObject;
+    private const string ActionKey = "Actions.Start";
+    private const string MoveCommand = "Move";
+
+    public RegisterIoCDependencyActionsStartTests()
+    {
+        SetupIoCScope();
+        _testObject = new Dictionary<string, object>();
+    }
+
+    private void SetupIoCScope()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        var scope = IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"));
+        IoC.Resolve<ICommand>("Scopes.Current.Set", scope).Execute();
+    }
+
+    [Fact]
+    public void DependencyRegistration_CreatesValidStartCommand()
+    {
+        RegisterAndValidateStartCommand();
+    }
+
+    private void RegisterAndValidateStartCommand()
+    {
+        new RegisterIoCDependencyActionsStart().Execute();
+        var command = IoC.Resolve<ICommand>(ActionKey, _testObject, MoveCommand);
+        ValidateCommand(command);
+    }
+
+    private void ValidateCommand(ICommand command)
+    {
+        Assert.NotNull(command);
+        Assert.IsType<StartCommand>(command);
+    }
+}

--- a/SpaceBattle.Tests/IoC/RegisterIoCDependencyActionsStartTests.cs
+++ b/SpaceBattle.Tests/IoC/RegisterIoCDependencyActionsStartTests.cs
@@ -33,11 +33,6 @@ public class RegisterIoCDependencyActionsStartTests
     {
         new RegisterIoCDependencyActionsStart().Execute();
         var command = IoC.Resolve<ICommand>(ActionKey, _testObject, MoveCommand);
-        ValidateCommand(command);
-    }
-
-    private void ValidateCommand(ICommand command)
-    {
         Assert.NotNull(command);
         Assert.IsType<StartCommand>(command);
     }

--- a/SpaceBattle.Tests/IoC/RegisterIoCDependencyActionsStopTests.cs
+++ b/SpaceBattle.Tests/IoC/RegisterIoCDependencyActionsStopTests.cs
@@ -1,0 +1,44 @@
+﻿namespace SpaceBattle.Tests;
+
+using Hwdtech;
+using Hwdtech.Ioc;
+using SpaceBattle.Lib;
+
+public class RegisterIoCDependencyActionsStopTests
+{
+    private readonly Dictionary<string, object> _testObject;
+    private const string ActionKey = "Actions.Stop";
+    private const string MoveCommand = "Move";
+
+    public RegisterIoCDependencyActionsStopTests()
+    {
+        SetupIoCScope();
+        _testObject = new Dictionary<string, object>();
+    }
+
+    private void SetupIoCScope()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        var scope = IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"));
+        IoC.Resolve<ICommand>("Scopes.Current.Set", scope).Execute();
+    }
+
+    [Fact]
+    public void DependencyRegistration_CreatesValidStopCommand()
+    {
+        RegisterAndValidateStopCommand();
+    }
+
+    private void RegisterAndValidateStopCommand()
+    {
+        new RegisterIoCDependencyActionsStop().Execute();
+        var command = IoC.Resolve<ICommand>(ActionKey, _testObject, MoveCommand);
+        ValidateCommand(command);
+    }
+
+    private void ValidateCommand(ICommand command)
+    {
+        Assert.NotNull(command);
+        Assert.IsType<StopCommand>(command);
+    }
+}

--- a/SpaceBattle.Tests/IoC/RegisterIoCDependencyActionsStopTests.cs
+++ b/SpaceBattle.Tests/IoC/RegisterIoCDependencyActionsStopTests.cs
@@ -33,11 +33,6 @@ public class RegisterIoCDependencyActionsStopTests
     {
         new RegisterIoCDependencyActionsStop().Execute();
         var command = IoC.Resolve<ICommand>(ActionKey, _testObject, MoveCommand);
-        ValidateCommand(command);
-    }
-
-    private void ValidateCommand(ICommand command)
-    {
         Assert.NotNull(command);
         Assert.IsType<StopCommand>(command);
     }

--- a/SpaceBattle.Tests/SendCommandTests.cs
+++ b/SpaceBattle.Tests/SendCommandTests.cs
@@ -1,0 +1,39 @@
+using Moq;
+using SpaceBattle.Lib;
+
+namespace SpaceBattle.Tests
+{
+    public class SendCommandTests
+    {
+        private readonly Mock<ICommandReceiver> _messageHandler;
+        private readonly Mock<ICommand> _longRunningTask;
+        private readonly ICommand _sendCommand;
+
+        public SendCommandTests()
+        {
+            _messageHandler = new Mock<ICommandReceiver>();
+            _longRunningTask = new Mock<ICommand>();
+            _sendCommand = new SendCommand(_longRunningTask.Object, _messageHandler.Object);
+        }
+
+        [Fact]
+        public void SendCommand_Successfully_Transfers_Command()
+        {
+            _messageHandler.Setup(x => x.Receive(_longRunningTask.Object));
+            _sendCommand.Execute();
+            _messageHandler.Verify(handler => handler.Receive(_longRunningTask.Object), Times.Once);
+        }
+
+        [Fact]
+        public void SendCommand_Propagates_Handler_Exception()
+        {
+            var expectedError = new Exception("Handler failure");
+            _messageHandler
+                .Setup(handler => handler.Receive(It.IsAny<ICommand>()))
+                .Throws(expectedError);
+
+            var actualError = Assert.Throws<Exception>(() => _sendCommand.Execute());
+            Assert.Same(expectedError, actualError);
+        }
+    }
+}

--- a/SpaceBattle.Tests/SendCommandTests.cs
+++ b/SpaceBattle.Tests/SendCommandTests.cs
@@ -1,5 +1,4 @@
-using Moq;
-using SpaceBattle.Lib;
+﻿using SpaceBattle.Lib;
 
 namespace SpaceBattle.Tests
 {


### PR DESCRIPTION
14. Определить команду SendCommand для отправки команды.
SendCommand в конструктор получает команду ICommand и интерфейс ICommandReceiver. В методе Execute SendCommand вызывается метод Receive интерфейса ICommandReceiver, в который передается длительная команда.

Критерии приемки:

Реализован тест "SendCommand передает команду в IMessageReceiver", который проверяет, что при вызове метода Execute класса SendCommand вызывается метод Receive объекта ICommandReceiver с параметром - объектом длительной команды.
Реализован тест, который проверяет, что SendCommand.Execute выбрасывает исключение, если IMessageReceiver не может принять длительную команду.
15. Определить зависимость "Commands.Send" в IoC, которая по команде и объекту типа IMessageReceiver конструирует команду SendCommand.
Указание: Для регистрации зависимости определить команду RegisterIoCDependencySendCommand:

public class RegisterIoCDependencySendCommand : ICommand
{
    public void Execute()
  {
      // код, регистрирующий зависимость
    }
}
Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterDependencySendCommand зависимость разрешается.
16. Определить интерфейс ICommandInjectable
public interface ICommandInjectable
{
    void Inject(ICommand command);
}

19. Определить зависимость "Actions.Start" для запуска длительной операции.
Необходимо так определить зависимость, чтобы следующий код позволял получать команду:

IDictionary<string, object> order = ...; // приказ о старте длительной операции
Ioc.Resolve<ICommand>("Actions.Start", order);
Сама регистрация зависимости должна быть выполнена в команде RegisterIoCDepenedncyActionsStart

public class RegisterIoCDependencyActionsStart : ICommand
{
    public void Execute()
  {
    // здесь код для регистрации зависимостей
  }
}
Примечание: Все дополнительные зависимости, которые будут использованы при реализации, кроме зависимостей, которые были оговорены выше, должны быть также зарегистрированы.

Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterIoCDependencyActionsStart зависимость разрешается.
20. Определить зависимость "Actions.Stop" для запуска длительной операции.
Необходимо так определить зависимость, чтобы следующий код позволял получать команду:

IDictionary<string, object> order = ...; // приказ об остановке длительной операции
Ioc.Resolve<ICommand>("Actions.Stop", order);
Сама регистрация зависимости должна быть выполнена в команде RegisterIoCDepenedncyActionsStop

public class RegisterIoCDependencyActionsStop : ICommand
{
    public void Execute()
  {
    // здесь код для регистрации зависимостей
  }
}
Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterIoCDependencyActionsStop зависимость разрешается.
Остановка команды выполняется за константное время.

